### PR TITLE
Prebuild fixes

### DIFF
--- a/bridgepoint/oal.py
+++ b/bridgepoint/oal.py
@@ -902,8 +902,11 @@ class OALParser(object):
                          'GE',
                          'PLUS',
                          'MINUS',
+                         'PIPE',
                          'DIV',
                          'MOD',
+                         'AMP',
+                         'CARET',
                          'COMMENT',
                          'SL_STRING'
         )
@@ -915,8 +918,8 @@ class OALParser(object):
         ('left', 'OR'),
         ('left', 'AND'),
         ('nonassoc', 'LESSTHAN', 'LE', 'DOUBLEEQUAL', 'GT', 'GE', 'NOTEQUAL'),
-        ('left', 'PLUS', "MINUS"),
-        ('left', "TIMES", "DIV"),
+        ('left', 'PLUS', 'MINUS', 'PIPE'),
+        ('left', 'TIMES', 'DIV', 'AMP', 'CARET'),
         ('left', 'MOD'),
         ('right', 'UNARY'),
     )
@@ -1106,6 +1109,11 @@ class OALParser(object):
         r"\-"
         t.endlexpos = t.lexpos + len(t.value)
         return t
+
+    def t_PIPE(self, t):
+        r"\|"
+        t.endlexpos = t.lexpos + len(t.value)
+        return t
     
     def t_DIV(self, t):
         r"/"
@@ -1116,7 +1124,17 @@ class OALParser(object):
         r"%"
         t.endlexpos = t.lexpos + len(t.value)
         return t
+ 
+    def t_AMP(self, t):
+        r"&"
+        t.endlexpos = t.lexpos + len(t.value)
+        return t
     
+    def t_CARET(self, t):
+        r"\^"
+        t.endlexpos = t.lexpos + len(t.value)
+        return t
+ 
     def t_newline(self, t):
         r'\n+'
         t.lexer.lineno += len(t.value)
@@ -1730,9 +1748,12 @@ class OALParser(object):
         '''
         expression : expression PLUS  expression
                    | expression MINUS expression
+                   | expression PIPE  expression
                    | expression TIMES expression
                    | expression DIV   expression
                    | expression MOD   expression
+                   | expression AMP   expression
+                   | expression CARET expression
         '''
         p[0] = BinaryOperationNode(left=p[1],
                                    operator=p[2],

--- a/bridgepoint/prebuild.py
+++ b/bridgepoint/prebuild.py
@@ -1582,12 +1582,21 @@ class TransitionPrebuilder(ActionPrebuilder):
         return ''
         
     def accept_BodyNode(self, node):
-        act_sab = self.new('ACT_SAB')
-        relate(act_sab, self._sm_act, 691)
-        
-        self.act_act = self.new('ACT_ACT')
-        
-        relate(act_sab, self.act_act, 698)
+        sm_moah = one(self._sm_act).SM_AH[514].SM_MOAH[513]()
+        if sm_moah is not None:
+            act_sab = self.new('ACT_SAB')
+            relate(act_sab, self._sm_act, 691)
+            
+            self.act_act = self.new('ACT_ACT')
+            
+            relate(act_sab, self.act_act, 698)
+        else:
+            act_tab = self.new('ACT_TAB')
+            relate(act_tab, self._sm_act, 688)
+            
+            self.act_act = self.new('ACT_ACT')
+            
+            relate(act_tab, self.act_act, 698)
         
         return ActionPrebuilder.accept_BodyNode(self, node)
 

--- a/tests/test_bridgepoint/test_binop.py
+++ b/tests/test_bridgepoint/test_binop.py
@@ -394,7 +394,239 @@ class TestBinOp(PrebuildFunctionTestCase):
         
         v_val = one(v_bin).V_VAL[803]()
         self.assertIsNotNone(v_val)
+
+    @prebuild_docstring
+    def test_union(self):
+        '''
+        select many objs1 from instances of OBJECT;
+        select many objs2 from instances of OBJECT;
+        return objs1 | objs2;
+        '''
+        act_ret = self.metamodel.select_one('ACT_RET')
+        self.assertIsNotNone(act_ret)
+
+        act_smt = one(act_ret).ACT_SMT[603]()
+        self.assertIsNotNone(act_smt)
         
+        v_val = one(act_ret).V_VAL[668]()
+        self.assertEqual(v_val.isLValue, False)
+        self.assertEqual(v_val.isImplicit, False)
+        self.assertEqual(v_val.LineNumber, 4)
+        self.assertEqual(v_val.StartPosition, 16)
+        self.assertEqual(v_val.EndPosition, 28)
+
+        s_dt = one(v_val).S_DT[820]()
+        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        
+        v_bin = one(v_val).V_BIN[801]()
+        self.assertEqual(v_bin.Operator, '|')
+        
+        v_val = one(v_bin).V_VAL[802]()
+        self.assertIsNotNone(v_val)
+        
+        v_val = one(v_bin).V_VAL[803]()
+        self.assertIsNotNone(v_val)
+
+    @prebuild_docstring
+    def test_union2(self):
+        '''
+        select many objs1 from instances of OBJECT;
+        select many objs2 from instances of OBJECT;
+        return objs1 + objs2;
+        '''
+        act_ret = self.metamodel.select_one('ACT_RET')
+        self.assertIsNotNone(act_ret)
+
+        act_smt = one(act_ret).ACT_SMT[603]()
+        self.assertIsNotNone(act_smt)
+        
+        v_val = one(act_ret).V_VAL[668]()
+        self.assertEqual(v_val.isLValue, False)
+        self.assertEqual(v_val.isImplicit, False)
+        self.assertEqual(v_val.LineNumber, 4)
+        self.assertEqual(v_val.StartPosition, 16)
+        self.assertEqual(v_val.EndPosition, 28)
+
+        s_dt = one(v_val).S_DT[820]()
+        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        
+        v_bin = one(v_val).V_BIN[801]()
+        self.assertEqual(v_bin.Operator, '+')
+        
+        v_val = one(v_bin).V_VAL[802]()
+        self.assertIsNotNone(v_val)
+        
+        v_val = one(v_bin).V_VAL[803]()
+        self.assertIsNotNone(v_val)
+
+    @prebuild_docstring
+    def test_intersection(self):
+        '''
+        select many objs1 from instances of OBJECT;
+        select many objs2 from instances of OBJECT;
+        return objs1 & objs2;
+        '''
+        act_ret = self.metamodel.select_one('ACT_RET')
+        self.assertIsNotNone(act_ret)
+
+        act_smt = one(act_ret).ACT_SMT[603]()
+        self.assertIsNotNone(act_smt)
+        
+        v_val = one(act_ret).V_VAL[668]()
+        self.assertEqual(v_val.isLValue, False)
+        self.assertEqual(v_val.isImplicit, False)
+        self.assertEqual(v_val.LineNumber, 4)
+        self.assertEqual(v_val.StartPosition, 16)
+        self.assertEqual(v_val.EndPosition, 28)
+
+        s_dt = one(v_val).S_DT[820]()
+        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        
+        v_bin = one(v_val).V_BIN[801]()
+        self.assertEqual(v_bin.Operator, '&')
+        
+        v_val = one(v_bin).V_VAL[802]()
+        self.assertIsNotNone(v_val)
+        
+        v_val = one(v_bin).V_VAL[803]()
+        self.assertIsNotNone(v_val)
+
+    @prebuild_docstring
+    def test_difference(self):
+        '''
+        select many objs1 from instances of OBJECT;
+        select many objs2 from instances of OBJECT;
+        return objs1 - objs2;
+        '''
+        act_ret = self.metamodel.select_one('ACT_RET')
+        self.assertIsNotNone(act_ret)
+
+        act_smt = one(act_ret).ACT_SMT[603]()
+        self.assertIsNotNone(act_smt)
+        
+        v_val = one(act_ret).V_VAL[668]()
+        self.assertEqual(v_val.isLValue, False)
+        self.assertEqual(v_val.isImplicit, False)
+        self.assertEqual(v_val.LineNumber, 4)
+        self.assertEqual(v_val.StartPosition, 16)
+        self.assertEqual(v_val.EndPosition, 28)
+
+        s_dt = one(v_val).S_DT[820]()
+        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        
+        v_bin = one(v_val).V_BIN[801]()
+        self.assertEqual(v_bin.Operator, '-')
+        
+        v_val = one(v_bin).V_VAL[802]()
+        self.assertIsNotNone(v_val)
+        
+        v_val = one(v_bin).V_VAL[803]()
+        self.assertIsNotNone(v_val)
+ 
+    @prebuild_docstring
+    def test_disunion(self):
+        '''
+        select many objs1 from instances of OBJECT;
+        select many objs2 from instances of OBJECT;
+        return objs1 ^ objs2;
+        '''
+        act_ret = self.metamodel.select_one('ACT_RET')
+        self.assertIsNotNone(act_ret)
+
+        act_smt = one(act_ret).ACT_SMT[603]()
+        self.assertIsNotNone(act_smt)
+        
+        v_val = one(act_ret).V_VAL[668]()
+        self.assertEqual(v_val.isLValue, False)
+        self.assertEqual(v_val.isImplicit, False)
+        self.assertEqual(v_val.LineNumber, 4)
+        self.assertEqual(v_val.StartPosition, 16)
+        self.assertEqual(v_val.EndPosition, 28)
+
+        s_dt = one(v_val).S_DT[820]()
+        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        
+        v_bin = one(v_val).V_BIN[801]()
+        self.assertEqual(v_bin.Operator, '^')
+        
+        v_val = one(v_bin).V_VAL[802]()
+        self.assertIsNotNone(v_val)
+        
+        v_val = one(v_bin).V_VAL[803]()
+        self.assertIsNotNone(v_val)
+
+    @prebuild_docstring
+    def test_union_ltr_precedence(self):
+        '''
+        select many objs1 from instances of OBJECT;
+        select many objs2 from instances of OBJECT;
+        select any obj3 from instances of OBJECT;
+        return objs1 | objs2 | obj3;
+        '''
+        act_ret = self.metamodel.select_one('ACT_RET')
+        self.assertIsNotNone(act_ret)
+
+        act_smt = one(act_ret).ACT_SMT[603]()
+        self.assertIsNotNone(act_smt)
+        
+        v_val = one(act_ret).V_VAL[668]()
+        self.assertEqual(v_val.isLValue, False)
+        self.assertEqual(v_val.isImplicit, False)
+        self.assertEqual(v_val.LineNumber, 5)
+        self.assertEqual(v_val.StartPosition, 16)
+        self.assertEqual(v_val.EndPosition, 35)
+
+        s_dt = one(v_val).S_DT[820]()
+        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        
+        v_bin = one(v_val).V_BIN[801]()
+        self.assertEqual(v_bin.Operator, '|')
+        
+        l_v_val = one(v_bin).V_VAL[802]()
+        self.assertIsNotNone(l_v_val)
+
+        l_v_bin = one(l_v_val).V_BIN[801]()
+        self.assertEqual(l_v_bin.Operator, '|')
+        
+        r_v_val = one(v_bin).V_VAL[803]()
+        self.assertIsNotNone(r_v_val)
+
+    @prebuild_docstring
+    def test_union_intersection_precedence(self):
+        '''
+        select many objs1 from instances of OBJECT;
+        select many objs2 from instances of OBJECT;
+        select any obj3 from instances of OBJECT;
+        return objs1 | objs2 & obj3;
+        '''
+        act_ret = self.metamodel.select_one('ACT_RET')
+        self.assertIsNotNone(act_ret)
+
+        act_smt = one(act_ret).ACT_SMT[603]()
+        self.assertIsNotNone(act_smt)
+        
+        v_val = one(act_ret).V_VAL[668]()
+        self.assertEqual(v_val.isLValue, False)
+        self.assertEqual(v_val.isImplicit, False)
+        self.assertEqual(v_val.LineNumber, 5)
+        self.assertEqual(v_val.StartPosition, 16)
+        self.assertEqual(v_val.EndPosition, 35)
+
+        s_dt = one(v_val).S_DT[820]()
+        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        
+        v_bin = one(v_val).V_BIN[801]()
+        self.assertEqual(v_bin.Operator, '|')
+        
+        l_v_val = one(v_bin).V_VAL[802]()
+        self.assertIsNotNone(l_v_val)
+        
+        r_v_val = one(v_bin).V_VAL[803]()
+        self.assertIsNotNone(r_v_val)
+
+        r_v_bin = one(r_v_val).V_BIN[801]()
+        self.assertEqual(r_v_bin.Operator, '&')
+ 
     
 if __name__ == "__main__":
     import logging

--- a/tests/test_bridgepoint/utils.py
+++ b/tests/test_bridgepoint/utils.py
@@ -371,7 +371,12 @@ class PrebuildFunctionTestCase(CompareAST):
         
         s_dt = self.metamodel.select_any('S_DT', lambda sel: sel.Name == 'void')
         xtuml.relate(s_dt, s_sync, 25)
-        
+
+        pe_pe2 = self.metamodel.new('PE_PE')
+        o_obj = self.metamodel.new('O_OBJ')
+        o_obj.Key_Lett = 'OBJECT'
+        xtuml.relate(o_obj, pe_pe2, 8001)
+
     def tearDown(self):
         del self.metamodel
         


### PR DESCRIPTION
Fixed bug where ACT_SAB instances were being created for both transition actions and state entry actions.

Added support in the parser for the set operations: union (|, +), intersection (&), difference (-), and disunion/symmetric difference (^). Added test cases for these.

Set operations were implemented in BP OAL parser last year (see [here](https://github.com/xtuml/bridgepoint/blob/master/doc-bridgepoint/notes/5007_set_operations/5007_set_operations_dnt.md)).