### PR TITLE
Set operation type

### DIFF
--- a/bridgepoint/prebuild.py
+++ b/bridgepoint/prebuild.py
@@ -311,6 +311,8 @@ class ActionPrebuilder(xtuml.tools.Walker):
 
     def v_avl(self, node, o_attr, root_v_val):
         s_dt = one(o_attr).S_DT[114]()
+        if s_dt == self.s_dt('same_as<Base_Attribute>'):
+            s_dt = one(o_attr).O_RATTR[106].O_BATTR[113].O_ATTR[106].S_DT[114]()
             
         v_val = self.v_val(node)
         v_avl = self.new('V_AVL')

--- a/bridgepoint/prebuild.py
+++ b/bridgepoint/prebuild.py
@@ -1014,18 +1014,18 @@ class ActionPrebuilder(xtuml.tools.Walker):
         v_val_r = self.accept(node.right)
 
         l_s_dt = one(v_val_l).S_DT[820]()
+        l_s_irdt = one(l_s_dt).S_IRDT[17]()
         if node.operator.lower() in ['<', '<=', '==', '!=', '>=', '>',
                                      'and', 'or']:
             s_dt = self.s_dt('boolean')
-        elif node.operator.lower() in ['|', '+', '&', '^', '-'] and (
+        elif node.operator.lower() in ['|', '+', '&', '^', '-'] and (l_s_irdt or
             l_s_dt == self.s_dt('inst_ref<Object>') or l_s_dt == self.s_dt('inst_ref_set<Object>')):
             # set the correct IRDT for set operation
-            # NOTE: this assumes that if the value is still a generic instance reference type that it
-            # is a result of a selection and therefore is an instance reference or instance set reference
-            s_irdt = one(v_val_l).V_IRF[801].V_VAR[808].V_INT[814].O_OBJ[818].S_IRDT[123](lambda sel: sel.isSet)
-            if s_irdt is None:
-                s_irdt = one(v_val_l).V_ISR[801].V_VAR[809].V_INS[814].O_OBJ[819].S_IRDT[123](lambda sel: sel.isSet)
-            s_dt = one(s_irdt).S_DT[17]()
+            if l_s_irdt is not None:
+                s_irdt = one(l_s_irdt).O_OBJ[123].S_IRDT[123](lambda sel: sel.isSet)
+                s_dt = one(s_irdt).S_DT[17]()
+            else:
+                s_dt = self.s_dt('inst_ref_set<Object>')
         else:
             s_dt = l_s_dt
         

--- a/bridgepoint/prebuild.py
+++ b/bridgepoint/prebuild.py
@@ -1389,7 +1389,7 @@ class ActionPrebuilder(xtuml.tools.Walker):
                          RequiredSig_Id=spr_rs.Id)
             
             elif spr_ps:
-                self.new('ACT_IOP',
+                self.new('ACT_SGN',
                          Statement_ID=act_smt.Statement_ID,
                          ProvidedSig_Id=spr_ps.Id)
         

--- a/tests/test_bridgepoint/test_binop.py
+++ b/tests/test_bridgepoint/test_binop.py
@@ -416,7 +416,7 @@ class TestBinOp(PrebuildFunctionTestCase):
         self.assertEqual(v_val.EndPosition, 28)
 
         s_dt = one(v_val).S_DT[820]()
-        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        self.assertEqual(s_dt.Name, 'inst_ref_set<OBJECT>')
         
         v_bin = one(v_val).V_BIN[801]()
         self.assertEqual(v_bin.Operator, '|')
@@ -448,7 +448,7 @@ class TestBinOp(PrebuildFunctionTestCase):
         self.assertEqual(v_val.EndPosition, 28)
 
         s_dt = one(v_val).S_DT[820]()
-        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        self.assertEqual(s_dt.Name, 'inst_ref_set<OBJECT>')
         
         v_bin = one(v_val).V_BIN[801]()
         self.assertEqual(v_bin.Operator, '+')
@@ -480,7 +480,7 @@ class TestBinOp(PrebuildFunctionTestCase):
         self.assertEqual(v_val.EndPosition, 28)
 
         s_dt = one(v_val).S_DT[820]()
-        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        self.assertEqual(s_dt.Name, 'inst_ref_set<OBJECT>')
         
         v_bin = one(v_val).V_BIN[801]()
         self.assertEqual(v_bin.Operator, '&')
@@ -512,7 +512,7 @@ class TestBinOp(PrebuildFunctionTestCase):
         self.assertEqual(v_val.EndPosition, 28)
 
         s_dt = one(v_val).S_DT[820]()
-        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        self.assertEqual(s_dt.Name, 'inst_ref_set<OBJECT>')
         
         v_bin = one(v_val).V_BIN[801]()
         self.assertEqual(v_bin.Operator, '-')
@@ -544,7 +544,7 @@ class TestBinOp(PrebuildFunctionTestCase):
         self.assertEqual(v_val.EndPosition, 28)
 
         s_dt = one(v_val).S_DT[820]()
-        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        self.assertEqual(s_dt.Name, 'inst_ref_set<OBJECT>')
         
         v_bin = one(v_val).V_BIN[801]()
         self.assertEqual(v_bin.Operator, '^')
@@ -577,7 +577,7 @@ class TestBinOp(PrebuildFunctionTestCase):
         self.assertEqual(v_val.EndPosition, 35)
 
         s_dt = one(v_val).S_DT[820]()
-        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        self.assertEqual(s_dt.Name, 'inst_ref_set<OBJECT>')
         
         v_bin = one(v_val).V_BIN[801]()
         self.assertEqual(v_bin.Operator, '|')
@@ -613,7 +613,7 @@ class TestBinOp(PrebuildFunctionTestCase):
         self.assertEqual(v_val.EndPosition, 35)
 
         s_dt = one(v_val).S_DT[820]()
-        self.assertEqual(s_dt.Name, 'inst_ref_set<Object>')
+        self.assertEqual(s_dt.Name, 'inst_ref_set<OBJECT>')
         
         v_bin = one(v_val).V_BIN[801]()
         self.assertEqual(v_bin.Operator, '|')

--- a/tests/test_bridgepoint/utils.py
+++ b/tests/test_bridgepoint/utils.py
@@ -375,7 +375,26 @@ class PrebuildFunctionTestCase(CompareAST):
         pe_pe2 = self.metamodel.new('PE_PE')
         o_obj = self.metamodel.new('O_OBJ')
         o_obj.Key_Lett = 'OBJECT'
+        o_obj.Name = 'OBJECT'
         xtuml.relate(o_obj, pe_pe2, 8001)
+
+        pe_pe3 = self.metamodel.new('PE_PE')
+        s_dt2 = self.metamodel.new('S_DT')
+        s_dt2.Name = 'inst_ref<OBJECT>'
+        s_irdt2 = self.metamodel.new('S_IRDT')
+        s_irdt2.isSet = False
+        xtuml.relate(s_dt2, pe_pe3, 8001)
+        xtuml.relate(s_irdt2, s_dt2, 17)
+        xtuml.relate(s_irdt2, o_obj, 123)
+
+        pe_pe4 = self.metamodel.new('PE_PE')
+        s_dt3 = self.metamodel.new('S_DT')
+        s_dt3.Name = 'inst_ref_set<OBJECT>'
+        s_irdt3 = self.metamodel.new('S_IRDT')
+        s_irdt3.isSet = True
+        xtuml.relate(s_dt3, pe_pe4, 8001)
+        xtuml.relate(s_irdt3, s_dt3, 17)
+        xtuml.relate(s_irdt3, o_obj, 123)
 
     def tearDown(self):
         del self.metamodel


### PR DESCRIPTION
Change the parser to set instance types to the specific S_IRDT instances if they exist for selections and binary set operations.

Also fixed two additional bugs found along the way.