### PR TITLE
support loading ooaofooa from zip archives

### DIFF
--- a/bridgepoint/ooaofooa.py
+++ b/bridgepoint/ooaofooa.py
@@ -23,6 +23,7 @@ import logging
 import zipfile
 import keyword
 import xtuml
+import io
 
 from xtuml import navigate_one as one
 from xtuml import navigate_many as many
@@ -524,7 +525,7 @@ class ModelLoader(xtuml.ModelLoader):
                 for zipinfo in zipinput.filelist:
                     if zipinfo.filename.endswith('.xtuml'):
                         with zipinput.open(zipinfo) as f:
-                            xtuml.ModelLoader.file_input(self, f)
+                            xtuml.ModelLoader.file_input(self, io.TextIOWrapper(f, encoding='UTF-8'))
         else:
             xtuml.ModelLoader.filename_input(self, path_or_filename)
 

--- a/bridgepoint/ooaofooa.py
+++ b/bridgepoint/ooaofooa.py
@@ -20,6 +20,7 @@ import collections
 import functools
 import os
 import logging
+import zipfile
 import keyword
 import xtuml
 
@@ -509,12 +510,21 @@ class ModelLoader(xtuml.ModelLoader):
         
         If the filename is a directory, files that ends with .xtuml located
         somewhere in the directory or sub directories will be loaded as well.
+
+        If the filename is a zip archive, files that ends with .xtuml located
+        somewhere in the archive will be loaded as well.
         '''
         if os.path.isdir(path_or_filename):
             for path, _, files in os.walk(path_or_filename):
                 for name in files:
                     if name.endswith('.xtuml'):
                         xtuml.ModelLoader.filename_input(self, os.path.join(path, name))
+        elif zipfile.is_zipfile(path_or_filename):
+            with zipfile.ZipFile(path_or_filename) as zipinput:
+                for zipinfo in zipinput.filelist:
+                    if zipinfo.filename.endswith('.xtuml'):
+                        with zipinput.open(zipinfo) as f:
+                            xtuml.ModelLoader.file_input(self, f)
         else:
             xtuml.ModelLoader.filename_input(self, path_or_filename)
 

--- a/tests/test_bridgepoint/test_ooaofooa.py
+++ b/tests/test_bridgepoint/test_ooaofooa.py
@@ -15,7 +15,9 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with pyxtuml. If not, see <http://www.gnu.org/licenses/>.
+import atexit
 import os
+import shutil
 import unittest
 import xtuml
 from bridgepoint import ooaofooa
@@ -40,7 +42,16 @@ class TestOoaOfOoa(unittest.TestCase):
         dirname = os.path.dirname(__file__) + os.sep + '..' + os.sep + 'resources'
         metamodel = ooaofooa.load_metamodel(dirname, load_globals=False)
         self.assertTrue(metamodel.select_any('S_DT', xtuml.where_eq(Name='integer')) is not None)
+
+    def test_zipfile_input(self):
+        dirname = os.path.dirname(__file__) + os.sep + '..' + os.sep + 'resources'
+        zipfile = shutil.make_archive(dirname, 'zip', dirname)
+        atexit.register(os.remove, zipfile)
+
+        metamodel = ooaofooa.load_metamodel(zipfile, load_globals=False)
         self.assertTrue(metamodel.select_any('S_DT', xtuml.where_eq(Name='integer')) is not None)
+        
+        
 if __name__ == "__main__":
     import logging
     

--- a/tests/test_bridgepoint/test_ooaofooa.py
+++ b/tests/test_bridgepoint/test_ooaofooa.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with pyxtuml. If not, see <http://www.gnu.org/licenses/>.
+import os
 import unittest
 import xtuml
 from bridgepoint import ooaofooa
@@ -35,7 +36,11 @@ class TestOoaOfOoa(unittest.TestCase):
         s = xtuml.serialize_instances(m)
         self.assertFalse(s)
         
-    
+    def test_folder_input(self):
+        dirname = os.path.dirname(__file__) + os.sep + '..' + os.sep + 'resources'
+        metamodel = ooaofooa.load_metamodel(dirname, load_globals=False)
+        self.assertTrue(metamodel.select_any('S_DT', xtuml.where_eq(Name='integer')) is not None)
+        self.assertTrue(metamodel.select_any('S_DT', xtuml.where_eq(Name='integer')) is not None)
 if __name__ == "__main__":
     import logging
     

--- a/xtuml/meta.py
+++ b/xtuml/meta.py
@@ -491,7 +491,7 @@ class MetaClass(object):
         self.indices = dict()
         self.links = dict()
         self.storage = list()
-        self.clazz = type(kind, (Class,), dict(__metaclass__=self))
+        self.clazz = type(str(kind), (Class,), dict(__metaclass__=self))
         
     def __call__(self, *args, **kwargs):
         '''


### PR DESCRIPTION
The xtUML metamodel can be loaded from a set of file or directory resources. Allow zip archives to be loaded as well. The behavior is the same as directories where any file that uses the .xtuml file extension within the archive will be loaded.