### PR TITLE
Explicitly import 'collections.abc' for python 3

### DIFF
--- a/xtuml/tools.py
+++ b/xtuml/tools.py
@@ -17,12 +17,13 @@
 # License along with pyxtuml. If not, see <http://www.gnu.org/licenses/>.
 import uuid
 
-import collections
 try:
     # Python 3.x
+    import collections.abc
     collectionsAbc = collections.abc
 except:
     # Python 2.7
+    import collections
     collectionsAbc = collections
 
 


### PR DESCRIPTION
Resolves #51 