### PR TITLE
delete link when done

### DIFF
--- a/xtuml/meta.py
+++ b/xtuml/meta.py
@@ -335,6 +335,8 @@ class Link(dict):
             return False
 
         self[instance].remove(another_instance)
+        if len(self[instance]) == 0:
+            del self[instance]
         return True
         
     def navigate(self, instance):


### PR DESCRIPTION
After disconnecting instances from links, delete the link. This was discovered by running a pyxtuml model which did many creates and relates and then unrelates and deletes.